### PR TITLE
set number for record in before_validation callback

### DIFF
--- a/lib/document_number/has_document_number.rb
+++ b/lib/document_number/has_document_number.rb
@@ -28,7 +28,7 @@ module DocumentNumber
 
         method_name = "auto_increment_#{options[:column]}"
 
-        before_create method_name
+        before_validation method_name
         after_initialize method_name, :if => Proc.new { with_number == true }
 
         define_method method_name do


### PR DESCRIPTION
If we have a presence validation on field that we wont to create with help of this gem - we will get a validation error, because number assignment is triggered in after_create callback which is after validation callbacks in ActiveRecord callbacks and validations stack