### PR TITLE
setting number in bafore_validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
+.idea
 log/*.log
 pkg/
 spec/dummy/db/*.sqlite3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Document Number lets you automacally assign number sequences for your rails mode
 
 1. Add Document Number to your `Gemfile`
 
-    `gem 'document_number', '~> 0.9.6'`
+    `gem 'document_number', '~> 0.10.0'`
 
 2. Generate a migration which will add a `document_numbers` table to your database
 

--- a/lib/document_number/has_document_number.rb
+++ b/lib/document_number/has_document_number.rb
@@ -28,7 +28,7 @@ module DocumentNumber
 
         method_name = "auto_increment_#{options[:column]}"
 
-        before_create method_name
+        before_validation method_name
         after_initialize method_name, :if => Proc.new { with_number == true }
 
         define_method method_name do

--- a/lib/document_number/has_document_number.rb
+++ b/lib/document_number/has_document_number.rb
@@ -50,6 +50,13 @@ module DocumentNumber
       rescue
         []
       end
+
+      def update_document_number(number, check = true)
+        document = self.to_s.underscore
+        doc_in_db = DocumentNumber.where(:document => document).last
+        return false if check && doc_in_db && doc_in_db.number.to_i > number.to_i
+        doc_in_db.update_attribute(:number, number)
+      end
     end
   end
 end

--- a/lib/document_number/has_document_number.rb
+++ b/lib/document_number/has_document_number.rb
@@ -51,10 +51,10 @@ module DocumentNumber
         []
       end
 
-      def update_document_number(number, check = true)
+      def update_document_number(number)
         document = self.to_s.underscore
         doc_in_db = DocumentNumber.where(:document => document).last
-        return false if check && doc_in_db && doc_in_db.number.to_i > number.to_i
+        return false if doc_in_db && doc_in_db.number.to_i > number.to_i
         doc_in_db.update_attribute(:number, number)
       end
     end

--- a/lib/document_number/version.rb
+++ b/lib/document_number/version.rb
@@ -1,3 +1,3 @@
 module DocumentNumber
-  VERSION = '0.9.6'
+  VERSION = '0.10.0'
 end

--- a/spec/dummy/app/models/supplier_complaint.rb
+++ b/spec/dummy/app/models/supplier_complaint.rb
@@ -1,0 +1,6 @@
+class SupplierComplaint < ActiveRecord::Base
+  has_document_number start: 500
+
+  validates :text, presence: true
+  validates :number, presence: true
+end

--- a/spec/dummy/db/migrate/20150617152432_supplier_complaints.rb
+++ b/spec/dummy/db/migrate/20150617152432_supplier_complaints.rb
@@ -1,0 +1,10 @@
+class SupplierComplaints < ActiveRecord::Migration
+  def change
+    create_table :supplier_complaints do |t|
+      t.string :number
+      t.string :text
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,30 +11,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140610093243) do
+ActiveRecord::Schema.define(version: 20150617152432) do
 
-  create_table "document_numbers", force: true do |t|
+  create_table "document_numbers", force: :cascade do |t|
     t.string   "document"
-    t.integer  "number",     null: false, default: 1
+    t.integer  "number",     default: 1, null: false
     t.datetime "created_at"
   end
 
   add_index "document_numbers", ["document"], name: "index_document_numbers_on_document", unique: true
 
-  create_table "inventories", force: true do |t|
+  create_table "inventories", force: :cascade do |t|
     t.string   "number"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "invoices", force: true do |t|
+  create_table "invoices", force: :cascade do |t|
     t.string   "number"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "price_adjustments", force: true do |t|
+  create_table "price_adjustments", force: :cascade do |t|
     t.string   "document_number"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "supplier_complaints", force: :cascade do |t|
+    t.string   "number"
+    t.string   "text"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/spec/models/supplier_complaint_spec.rb
+++ b/spec/models/supplier_complaint_spec.rb
@@ -2,10 +2,8 @@ require 'spec_helper'
 
 describe SupplierComplaint do
   context 'without prefix' do
-    before(:each) do
+    before do
       SupplierComplaint.has_document_number(prefix: nil, start: 500)
-      # document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
-      # document_row.update_attributes(number: 1) if document_row
     end
 
     it 'uses default column' do
@@ -25,30 +23,34 @@ describe SupplierComplaint do
       expect(supplier_complaint2.number).to eq('501')
     end
 
-    it 'if validation fails next record gets correct number' do
-      supplier_complaint1 = SupplierComplaint.create(text: 'complaint1')
-      supplier_complaint2 = SupplierComplaint.create(text: '')
-      supplier_complaint3 = SupplierComplaint.create(text: 'complaint3')
-      expect(supplier_complaint1.number).to eq('500')
-      expect(supplier_complaint2).to be_invalid
-      expect(supplier_complaint3.number).to eq('501')
-    end
+    context 'validation fails' do
+      it 'next record gets correct number' do
+        supplier_complaint1 = SupplierComplaint.create(text: 'complaint1')
+        supplier_complaint2 = SupplierComplaint.create(text: '')
+        supplier_complaint3 = SupplierComplaint.create(text: 'complaint3')
+        expect(supplier_complaint1.number).to eq('500')
+        expect(supplier_complaint2).to be_invalid
+        expect(supplier_complaint3.number).to eq('501')
+      end
 
-    it 'if validation fails next records g correct number' do
-      supplier_complaint1 = SupplierComplaint.create(text: '')
-      supplier_complaint2 = SupplierComplaint.create(text: 'complaint2')
-      supplier_complaint3 = SupplierComplaint.create(text: 'complaint3')
-      expect(supplier_complaint1).to be_invalid
-      expect(supplier_complaint2.number).to eq('500')
-      expect(supplier_complaint3.number).to eq('501')
+      it 'next records get correct number' do
+        supplier_complaint1 = SupplierComplaint.create(text: '')
+        supplier_complaint2 = SupplierComplaint.create(text: 'complaint2')
+        supplier_complaint3 = SupplierComplaint.create(text: 'complaint3')
+        expect(supplier_complaint1).to be_invalid
+        expect(supplier_complaint2.number).to eq('500')
+        expect(supplier_complaint3.number).to eq('501')
+      end
     end
 
     it 'gets array of numbers' do
       expect(SupplierComplaint.get_numbers(3)).to eq(%w(500 501 502))
     end
 
-    it 'assigns number after initialization if has with_number' do
-      expect(SupplierComplaint.new(with_number: true).number).to eq('500')
+    context 'has with_number' do
+      it 'assigns number after initialization' do
+        expect(SupplierComplaint.new(with_number: true).number).to eq('500')
+      end
     end
 
     it 'does not assign number after initialization' do
@@ -57,10 +59,8 @@ describe SupplierComplaint do
   end
 
   context 'with prefix' do
-    before(:each) do
+    before do
       SupplierComplaint.has_document_number(prefix: 'prefix/', start: 500)
-      # document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
-      # document_row.update_attributes(number: 1) if document_row
     end
 
     it 'uses default column' do
@@ -80,21 +80,25 @@ describe SupplierComplaint do
       expect(supplier_complaint2.number).to eq('prefix/501')
     end
 
-    it 'if validation fails next record gets correct number' do
-      supplier_complaint1 = SupplierComplaint.create(text: 'complaint1')
-      supplier_complaint2 = SupplierComplaint.create(text: '')
-      supplier_complaint3 = SupplierComplaint.create(text: 'complaint3')
-      expect(supplier_complaint1.number).to eq('prefix/500')
-      expect(supplier_complaint2).to be_invalid
-      expect(supplier_complaint3.number).to eq('prefix/501')
+    context 'validation fails' do
+      it 'next record gets correct number' do
+        supplier_complaint1 = SupplierComplaint.create(text: 'complaint1')
+        supplier_complaint2 = SupplierComplaint.create(text: '')
+        supplier_complaint3 = SupplierComplaint.create(text: 'complaint3')
+        expect(supplier_complaint1.number).to eq('prefix/500')
+        expect(supplier_complaint2).to be_invalid
+        expect(supplier_complaint3.number).to eq('prefix/501')
+      end
     end
 
     it 'gets array of numbers' do
       expect(SupplierComplaint.get_numbers(3)).to eq(%w(prefix/500 prefix/501 prefix/502))
     end
 
-    it 'assigns number after initialization if has with_number' do
-      expect(SupplierComplaint.new(with_number: true).number).to eq('prefix/500')
+    context 'has with_number' do
+      it 'assigns number after initialization' do
+        expect(SupplierComplaint.new(with_number: true).number).to eq('prefix/500')
+      end
     end
 
     it 'does not assign number after initialization' do
@@ -103,7 +107,7 @@ describe SupplierComplaint do
   end
 
   context '#update_document_number' do
-    before(:each) do
+    before do
       SupplierComplaint.has_document_number(prefix: nil, start: 500)
       SupplierComplaint.create!(text: 'complaint')
     end
@@ -125,11 +129,13 @@ describe SupplierComplaint do
     end
 
     context 'new number is less then old' do
-      it 'updates number if check = false' do
-        result = SupplierComplaint.update_document_number(400, false)
-        document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
-        expect(result).to be true
-        expect(document_row.number).to eq 400
+      context 'check = false' do
+        it 'updates number' do
+          result = SupplierComplaint.update_document_number(400, false)
+          document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
+          expect(result).to be true
+          expect(document_row.number).to eq 400
+        end
       end
 
       it 'not updating number' do

--- a/spec/models/supplier_complaint_spec.rb
+++ b/spec/models/supplier_complaint_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe SupplierComplaint do
+  context 'without prefix' do
+    before(:each) do
+      SupplierComplaint.has_document_number(prefix: nil, start: 500)
+      # document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
+      # document_row.update_attributes(number: 1) if document_row
+    end
+
+    it 'uses default column' do
+      supplier_complaint = SupplierComplaint.create
+      expect(supplier_complaint.number).not_to be_nil
+    end
+
+    it 'starts from predefined value' do
+      supplier_complaint = SupplierComplaint.create(text: 'some')
+      expect(supplier_complaint.number).to eq('500')
+    end
+
+    it 'has sequence of numbers' do
+      supplier_complaint1 = SupplierComplaint.create(text: 'complaint1')
+      supplier_complaint2 = SupplierComplaint.create(text: 'complaint2')
+      expect(supplier_complaint1.number).to eq('500')
+      expect(supplier_complaint2.number).to eq('501')
+    end
+
+    it 'if validation fails next record gets correct number' do
+      supplier_complaint1 = SupplierComplaint.create(text: 'complaint1')
+      supplier_complaint2 = SupplierComplaint.create(text: '')
+      supplier_complaint3 = SupplierComplaint.create(text: 'complaint3')
+      expect(supplier_complaint1.number).to eq('500')
+      expect(supplier_complaint2).to be_invalid
+      expect(supplier_complaint3.number).to eq('501')
+    end
+
+    it 'if validation fails next records g correct number' do
+      supplier_complaint1 = SupplierComplaint.create(text: '')
+      supplier_complaint2 = SupplierComplaint.create(text: 'complaint2')
+      supplier_complaint3 = SupplierComplaint.create(text: 'complaint3')
+      expect(supplier_complaint1).to be_invalid
+      expect(supplier_complaint2.number).to eq('500')
+      expect(supplier_complaint3.number).to eq('501')
+    end
+
+    it 'gets array of numbers' do
+      expect(SupplierComplaint.get_numbers(3)).to eq(%w(500 501 502))
+    end
+
+    it 'assigns number after initialization if has with_number' do
+      expect(SupplierComplaint.new(with_number: true).number).to eq('500')
+    end
+
+    it 'does not assign number after initialization' do
+      expect(SupplierComplaint.new.number).to be_nil
+    end
+  end
+
+  context 'with prefix' do
+    before(:each) do
+      SupplierComplaint.has_document_number(prefix: 'prefix/', start: 500)
+      # document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
+      # document_row.update_attributes(number: 1) if document_row
+    end
+
+    it 'uses default column' do
+      supplier_complaint = SupplierComplaint.create
+      expect(supplier_complaint.number).not_to be_nil
+    end
+
+    it 'starts from predefined value' do
+      supplier_complaint = SupplierComplaint.create(text: 'some')
+      expect(supplier_complaint.number).to eq('prefix/500')
+    end
+
+    it 'has sequence of numbers' do
+      supplier_complaint1 = SupplierComplaint.create(text: 'complaint1')
+      supplier_complaint2 = SupplierComplaint.create(text: 'complaint2')
+      expect(supplier_complaint1.number).to eq('prefix/500')
+      expect(supplier_complaint2.number).to eq('prefix/501')
+    end
+
+    it 'if validation fails next record gets correct number' do
+      supplier_complaint1 = SupplierComplaint.create(text: 'complaint1')
+      supplier_complaint2 = SupplierComplaint.create(text: '')
+      supplier_complaint3 = SupplierComplaint.create(text: 'complaint3')
+      expect(supplier_complaint1.number).to eq('prefix/500')
+      expect(supplier_complaint2).to be_invalid
+      expect(supplier_complaint3.number).to eq('prefix/501')
+    end
+
+    it 'gets array of numbers' do
+      expect(SupplierComplaint.get_numbers(3)).to eq(%w(prefix/500 prefix/501 prefix/502))
+    end
+
+    it 'assigns number after initialization if has with_number' do
+      expect(SupplierComplaint.new(with_number: true).number).to eq('prefix/500')
+    end
+
+    it 'does not assign number after initialization' do
+      expect(SupplierComplaint.new.number).to be_nil
+    end
+  end
+end

--- a/spec/models/supplier_complaint_spec.rb
+++ b/spec/models/supplier_complaint_spec.rb
@@ -129,15 +129,6 @@ describe SupplierComplaint do
     end
 
     context 'new number is less then old' do
-      context 'check = false' do
-        it 'updates number' do
-          result = SupplierComplaint.update_document_number(400, false)
-          document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
-          expect(result).to be true
-          expect(document_row.number).to eq 400
-        end
-      end
-
       it 'not updating number' do
         result = SupplierComplaint.update_document_number(400)
         document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')

--- a/spec/models/supplier_complaint_spec.rb
+++ b/spec/models/supplier_complaint_spec.rb
@@ -101,4 +101,43 @@ describe SupplierComplaint do
       expect(SupplierComplaint.new.number).to be_nil
     end
   end
+
+  context '#update_document_number' do
+    before(:each) do
+      SupplierComplaint.has_document_number(prefix: nil, start: 500)
+      SupplierComplaint.create!(text: 'complaint')
+    end
+
+    context 'new number is greater or equal then old' do
+      it 'updates number' do
+        result = SupplierComplaint.update_document_number(505)
+        document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
+        expect(result).to be true
+        expect(document_row.number).to eq 505
+      end
+
+      it 'updates number if new number equals to old' do
+        result = SupplierComplaint.update_document_number(501)
+        document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
+        expect(result).to be true
+        expect(document_row.number).to eq 501
+      end
+    end
+
+    context 'new number is less then old' do
+      it 'updates number if check = false' do
+        result = SupplierComplaint.update_document_number(400, false)
+        document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
+        expect(result).to be true
+        expect(document_row.number).to eq 400
+      end
+
+      it 'not updating number' do
+        result = SupplierComplaint.update_document_number(400)
+        document_row = DocumentNumber::DocumentNumber.find_by_document('supplier_complaint')
+        expect(result).to be false
+        expect(document_row.number).to eq 501
+      end
+    end
+  end
 end


### PR DESCRIPTION
If we have a presence validation on field that we wont to create with help of this gem - we will get a validation error, because number assignment is triggered in after_create callback which is after validation callbacks in ActiveRecord callbacks and validations stack